### PR TITLE
Updated to work with Rails 4.2+ (fix bundler issue)

### DIFF
--- a/lib/tmdb-api/version.rb
+++ b/lib/tmdb-api/version.rb
@@ -1,3 +1,3 @@
 module TMDb
-  VERSION = '0.0.8'
+  VERSION = '0.0.9'
 end

--- a/tmdb-api.gemspec
+++ b/tmdb-api.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "httparty", "~> 0.13.0"
-  spec.add_dependency "activesupport", "~> 4.1.8"
+  spec.add_dependency "activesupport", ">= 4.1.8"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
I just tried updating my app to Rails 4.2.0, which was released earlier.

But when I tried to upgrade `bundler` gave me the following error:

```
Bundler could not find compatible versions for gem "activesupport":
  In Gemfile:
    rails (~> 4.2.0) ruby depends on
      activesupport (= 4.2.0) ruby

    tmdb-api (~> 0.0.8) ruby depends on
      activesupport (4.1.8)
```

I fixed this by changing the 4.1.x ActiveSupport requirement to a minimum 4.1.8 requirement.
